### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ http:
      headerName: "X-Trace-Id"
      # uuidGen indicates the type of UUID to generate, 4 being default, 7 being a k-sortable type, L being a ULID
      uuidGen: 4
+     # addToResponse indicates whether to add the header to the response
+     addToResponse: "true"
 ```
 
 Please note that traefik requires at least one configuration variable set, to keep the defaults you can set `trustAllIPs: false` to accomodate this. *This is not a requirement of this plugin, but a traefik requirement.*


### PR DESCRIPTION
Add addToResponse into docs. 
There is a problem where in case that the service which header is forwarded to responds with another header with same name same value this plugin will duplicate the value on the response to the user. 

The fix is to disable the returning from traefik plugin level and let the downstream service take care of that